### PR TITLE
Remove warning message from TSLint

### DIFF
--- a/angular-material/src/app/ag-grid-material-datepicker-editor/ag-grid-material-datepicker-editor.component.ts
+++ b/angular-material/src/app/ag-grid-material-datepicker-editor/ag-grid-material-datepicker-editor.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewChild} from '@angular/core';
+import {Component, OnInit, ViewChild, AfterViewInit} from '@angular/core';
 import {ICellEditorParams} from 'ag-grid/main';
 import {AgEditorComponent} from 'ag-grid-angular';
 import {MatDatepicker} from '@angular/material';
@@ -21,7 +21,7 @@ import {MatDatepicker} from '@angular/material';
         `
     ]
 })
-export class AgGridMaterialDatepickerEditorComponent implements OnInit, AgEditorComponent {
+export class AgGridMaterialDatepickerEditorComponent implements OnInit, AgEditorComponent, AfterViewInit {
     columnWidth: string;
     params: ICellEditorParams;
     private value: string;


### PR DESCRIPTION
Warning Message from TSLint: "Implement life cycle hook interface AfterViewInit for method ngAfterViewInit in class InputDatepickerComponent (https://angular.io/styleguide#style-09-01)"

The code has ngAfterViewInit Lifecycle Hook, because this, it is necessary to add implements AfterViewInit to make TSLint happy